### PR TITLE
revert solo cloudflare parameter since it is generating error - there…

### DIFF
--- a/stacks/traefik-lb/roles/cloudflare/tasks/main.yml
+++ b/stacks/traefik-lb/roles/cloudflare/tasks/main.yml
@@ -23,7 +23,6 @@
     record: "{{ cf_record }}"
     type: A
     value: "{{ ansible_ssh_host }}"
-    solo: "true"
     state: "present"
     account_email: "{{ cf_mail }}"
     account_api_token: "{{ cf_token }}"


### PR DESCRIPTION
@mcapuccini  Revert solo cloudflare parameter since it is generating error - there is currently no way with Ansible to delete previous A records